### PR TITLE
Add burn-free manual-gradient HMC/NUTS, fix a run_chain_progress panic, migrate coverage tooling

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -57,20 +57,24 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    container:
-      image: xd009642/tarpaulin:develop-nightly
-      options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Fontconfig dependency
-        run: apt-get update && apt-get install -y libfontconfig1-dev
+        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+      - name: Install the Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: llvm-tools-preview
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Rust Cache Action
+        uses: Swatinem/rust-cache@v2
       - name: Generate code coverage
-        run: |
-          cargo +nightly tarpaulin --verbose \
-          --all-features --workspace --timeout 120 --out xml
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.json
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
           fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +98,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -1124,6 +1145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,6 +1207,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1242,31 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codespan-reporting"
@@ -1337,6 +1416,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3692,6 +3806,7 @@ dependencies = [
  "approx",
  "arrow",
  "burn",
+ "criterion",
  "csv",
  "indicatif",
  "ndarray",
@@ -4089,6 +4204,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4110,6 +4231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4259,6 +4390,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -5523,7 +5682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5682,6 +5841,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,18 @@ approx = "0.5"
 ndarray = { version = "0.16", features = ["approx"] }
 plotly = "0.13"
 tempfile = "3.23"
+criterion = "0.8"
+
+[[bench]]
+name = "hmc_bench"
+harness = false
+
+[[bench]]
+name = "nuts_bench"
+harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(coverage_nightly)"] }
 
 [profile.dev]
 debug = true

--- a/benches/hmc_bench.rs
+++ b/benches/hmc_bench.rs
@@ -1,0 +1,170 @@
+//! Wall-clock benchmarks for `HMC` and `ManualHMC`, migrated from `#[ignore]`d tests in
+//! `src/hmc.rs`. Run with `cargo bench --bench hmc_bench` (add `--features wgpu` for the
+//! WGPU benchmark). These measure timing only; correctness is covered by the crate's
+//! regular (non-ignored) test suite.
+
+use burn::backend::{Autodiff, NdArray};
+use criterion::{criterion_group, criterion_main, Criterion};
+use mini_mcmc::core::{init, init_det, ChainRunner};
+use mini_mcmc::distributions::{Rosenbrock2D, RosenbrockND};
+use mini_mcmc::hmc::{ManualHMC, HMC};
+use std::hint::black_box;
+
+type BackendType = Autodiff<NdArray>;
+
+/// Ported from `hmc::tests::test_bench_noprogress`.
+fn bench_noprogress(c: &mut Criterion) {
+    c.bench_function("hmc_noprogress_6chains_5000collect", |b| {
+        b.iter(|| {
+            let target = Rosenbrock2D {
+                a: 1.0_f32,
+                b: 100.0_f32,
+            };
+            let initial_positions = init(6, 2);
+            let mut sampler = HMC::<f32, BackendType, Rosenbrock2D<f32>>::new(
+                target,
+                initial_positions,
+                0.01,
+                50,
+            )
+            .set_seed(42);
+            let sample = sampler.run(5000, 500);
+            assert_eq!(sample.dims(), [6, 5000, 2]);
+            black_box(sample);
+        });
+    });
+}
+
+/// Ported from `hmc::tests::test_progress_bench`.
+fn bench_progress(c: &mut Criterion) {
+    c.bench_function("hmc_progress_6chains_1000collect", |b| {
+        b.iter(|| {
+            let target = Rosenbrock2D {
+                a: 1.0_f32,
+                b: 100.0_f32,
+            };
+            let n_chains = 6;
+            let initial_positions = vec![vec![1.0_f32, 2.0_f32]; n_chains];
+            let mut sampler = HMC::<f32, BackendType, Rosenbrock2D<f32>>::new(
+                target,
+                initial_positions,
+                0.01,
+                50,
+            )
+            .set_seed(42);
+            let (sample, _stats) = sampler.run_progress(1000, 1000).unwrap();
+            assert_eq!(sample.dims(), [n_chains, 1000, 2]);
+            black_box(sample);
+        });
+    });
+}
+
+/// Ported from `hmc::tests::test_bench_10000d`.
+fn bench_10000d(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hmc_10000d");
+    group.sample_size(10);
+    group.bench_function("run_6chains_100collect", |b| {
+        b.iter(|| {
+            let d = 10000;
+            let n_chains = 6;
+            let initial_positions: Vec<Vec<f32>> = init_det(n_chains, d);
+            let mut sampler = HMC::<f32, BackendType, RosenbrockND>::new(
+                RosenbrockND {},
+                initial_positions,
+                0.01,
+                50,
+            )
+            .set_seed(42);
+            let sample = sampler.run(100, 100);
+            assert_eq!(sample.dims(), [n_chains, 100, d]);
+            black_box(sample);
+        });
+    });
+    group.finish();
+}
+
+/// Ported from `hmc::tests::test_progress_10000d_bench`.
+#[cfg(feature = "wgpu")]
+fn bench_10000d_wgpu_progress(c: &mut Criterion) {
+    use burn::backend::Wgpu;
+    type WgpuBackend = Autodiff<Wgpu>;
+
+    let mut group = c.benchmark_group("hmc_10000d_wgpu");
+    group.sample_size(10);
+    group.bench_function("run_progress_6chains_100collect", |b| {
+        b.iter(|| {
+            let d = 10000;
+            let n_chains = 6;
+            let initial_positions: Vec<Vec<f32>> = init_det(n_chains, d);
+            let mut sampler = HMC::<f32, WgpuBackend, RosenbrockND>::new(
+                RosenbrockND {},
+                initial_positions,
+                0.01,
+                50,
+            )
+            .set_seed(42);
+            let (sample, _stats) = sampler.run_progress(100, 100).unwrap();
+            assert_eq!(sample.dims(), [n_chains, 100, d]);
+            black_box(sample);
+        });
+    });
+    group.finish();
+}
+
+/// Ported from `hmc::tests::manual_hmc_vs_hmc_bench_10000d`: compares `HMC` (burn
+/// autodiff) against `ManualHMC` (analytic gradient) on the same high-dimensional
+/// target, as two named benchmarks in the same group for direct comparison.
+fn bench_manual_vs_burn_10000d(c: &mut Criterion) {
+    let d = 10000;
+    let n_chains = 6;
+    let initial_positions: Vec<Vec<f32>> = init_det(n_chains, d);
+
+    let mut group = c.benchmark_group("hmc_manual_vs_burn_10000d");
+    group.sample_size(10);
+
+    group.bench_function("burn_autodiff", |b| {
+        b.iter(|| {
+            let mut sampler = HMC::<f32, BackendType, RosenbrockND>::new(
+                RosenbrockND {},
+                initial_positions.clone(),
+                0.01,
+                50,
+            )
+            .set_seed(42);
+            let sample = sampler.run(100, 100);
+            assert_eq!(sample.dims(), [n_chains, 100, d]);
+            black_box(sample);
+        });
+    });
+
+    group.bench_function("manual_analytic_gradient", |b| {
+        b.iter(|| {
+            let mut sampler =
+                ManualHMC::new(RosenbrockND {}, initial_positions.clone(), 0.01, 50).set_seed(42);
+            let sample = sampler.run(100, 100).unwrap();
+            assert_eq!(sample.shape(), [n_chains, 100, d]);
+            black_box(sample);
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(feature = "wgpu")]
+criterion_group!(
+    benches,
+    bench_noprogress,
+    bench_progress,
+    bench_10000d,
+    bench_10000d_wgpu_progress,
+    bench_manual_vs_burn_10000d,
+);
+#[cfg(not(feature = "wgpu"))]
+criterion_group!(
+    benches,
+    bench_noprogress,
+    bench_progress,
+    bench_10000d,
+    bench_manual_vs_burn_10000d,
+);
+criterion_main!(benches);

--- a/benches/nuts_bench.rs
+++ b/benches/nuts_bench.rs
@@ -1,0 +1,105 @@
+//! Wall-clock benchmarks for `NUTS` and `ManualNUTS`, migrated from `#[ignore]`d tests
+//! in `src/nuts.rs`. Run with `cargo bench --bench nuts_bench`. These measure timing
+//! only; correctness is covered by the crate's regular (non-ignored) test suite.
+
+use burn::backend::{Autodiff, NdArray};
+use burn::prelude::Tensor;
+use criterion::{criterion_group, criterion_main, Criterion};
+use mini_mcmc::core::{init, init_det, ChainRunner};
+use mini_mcmc::distributions::Rosenbrock2D;
+use mini_mcmc::nuts::{ManualNUTS, NUTS};
+use std::hint::black_box;
+
+type BackendType = Autodiff<NdArray>;
+
+/// Ported from `nuts::tests::test_bench_noprogress_1`.
+fn bench_noprogress_1(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nuts_noprogress");
+    group.sample_size(10);
+    group.bench_function("6chains_5000collect", |b| {
+        b.iter(|| {
+            let target = Rosenbrock2D {
+                a: 1.0_f32,
+                b: 100.0_f32,
+            };
+            let initial_positions = init::<f32>(6, 2);
+            let mut sampler = NUTS::new(target, initial_positions, 0.95).set_seed(42);
+            let sample: Tensor<BackendType, 3> = sampler.run(5000, 500);
+            assert_eq!(sample.dims(), [6, 5000, 2]);
+            black_box(sample);
+        });
+    });
+    group.finish();
+}
+
+/// Ported from `nuts::tests::test_bench_noprogress_2`.
+fn bench_noprogress_2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nuts_noprogress");
+    group.sample_size(10);
+    group.bench_function("6chains_1000collect_1000discard", |b| {
+        b.iter(|| {
+            let target = Rosenbrock2D {
+                a: 1.0_f32,
+                b: 100.0_f32,
+            };
+            let initial_positions = init::<f32>(6, 2);
+            let mut sampler = NUTS::new(target, initial_positions, 0.95).set_seed(42);
+            let sample: Tensor<BackendType, 3> = sampler.run(1000, 1000);
+            assert_eq!(sample.dims(), [6, 1000, 2]);
+            black_box(sample);
+        });
+    });
+    group.finish();
+}
+
+/// Ported from `nuts::tests::manual_nuts_vs_nuts_bench`: compares `NUTS` (burn
+/// autodiff) against `ManualNUTS` (analytic gradient) on the same target, as two named
+/// benchmarks in the same group for direct comparison.
+fn bench_manual_vs_burn(c: &mut Criterion) {
+    let n_chains = 6;
+    let n_collect = 1000;
+    let n_discard = 500;
+    let initial_positions: Vec<Vec<f32>> = init_det(n_chains, 2);
+
+    let mut group = c.benchmark_group("nuts_manual_vs_burn");
+    group.sample_size(10);
+
+    group.bench_function("burn_autodiff", |b| {
+        b.iter(|| {
+            let mut sampler = NUTS::new(
+                Rosenbrock2D { a: 1.0, b: 100.0 },
+                initial_positions.clone(),
+                0.8,
+            )
+            .set_seed(42);
+            let sample: Tensor<BackendType, 3> = sampler.run(n_collect, n_discard);
+            assert_eq!(sample.dims(), [n_chains, n_collect, 2]);
+            black_box(sample);
+        });
+    });
+
+    group.bench_function("manual_analytic_gradient", |b| {
+        b.iter(|| {
+            let mut sampler = ManualNUTS::new(
+                Rosenbrock2D { a: 1.0, b: 100.0 },
+                initial_positions.clone(),
+                0.8,
+                n_discard,
+            )
+            .set_seed(42);
+            let sample = sampler.run(n_collect, n_discard).unwrap();
+            assert_eq!(sample.shape(), [n_chains, n_collect, 2]);
+            black_box(sample);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_noprogress_1,
+    bench_noprogress_2,
+    bench_manual_vs_burn,
+);
+criterion_main!(benches);

--- a/src/core.rs
+++ b/src/core.rs
@@ -107,6 +107,15 @@ where
 
     for i in 0..total {
         let current_state = chain.step();
+        if current_state.len() != n_params {
+            let msg = format!(
+                "Chain state dimensionality changed: expected {} elements, got {}.\nAborting generation of further observations.",
+                n_params,
+                current_state.len()
+            );
+            println!("{}", msg);
+            return Err(msg);
+        }
         tracker.step(current_state).map_err(|e| {
             let msg = format!(
             "Chain statistics tracker caused error: {}.\nAborting generation of further observations.",
@@ -432,4 +441,103 @@ where
                 .collect()
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A chain whose reported state length changes after the first step, used to
+    /// check that `run_chain_progress` rejects it with a clean `Err` instead of
+    /// panicking. `first_len`/`later_len` cover both directions: a state that grows
+    /// (first call establishes a smaller `n_params` than later calls report) used to
+    /// panic with an ndarray broadcast error from the fixed-width output array,
+    /// rather than returning `Err` like the shrinking direction already did.
+    struct InconsistentDimChain {
+        step_count: usize,
+        first_len: usize,
+        later_len: usize,
+        state: Vec<f64>,
+    }
+
+    impl MarkovChain<f64> for InconsistentDimChain {
+        fn step(&mut self) -> &Vec<f64> {
+            self.step_count += 1;
+            let len = if self.step_count == 1 {
+                self.first_len
+            } else {
+                self.later_len
+            };
+            self.state = vec![0.0; len];
+            &self.state
+        }
+
+        fn current_state(&self) -> &Vec<f64> {
+            &self.state
+        }
+    }
+
+    fn assert_dim_change_is_rejected(first_len: usize, later_len: usize) {
+        let mut chain = InconsistentDimChain {
+            step_count: 0,
+            first_len,
+            later_len,
+            state: vec![0.0; first_len],
+        };
+        let (tx, _rx) = mpsc::channel();
+        let result = run_chain_progress(&mut chain, 5, 0, tx);
+        assert!(
+            result.is_err(),
+            "expected a dimension change ({first_len} -> {later_len}) to be rejected as Err, got Ok"
+        );
+    }
+
+    #[test]
+    fn run_chain_progress_rejects_growing_state() {
+        assert_dim_change_is_rejected(2, 3);
+    }
+
+    #[test]
+    fn run_chain_progress_rejects_shrinking_state() {
+        assert_dim_change_is_rejected(3, 2);
+    }
+
+    #[test]
+    fn run_chain_progress_tolerates_dropped_stats_receiver() {
+        // The stats channel is a best-effort side reporting path (used by
+        // ChainRunner::run_progress's live progress bars); losing its receiver
+        // shouldn't abort sampling, just skip reporting for that tick.
+        let mut chain = InconsistentDimChain {
+            step_count: 0,
+            first_len: 2,
+            later_len: 2,
+            state: vec![0.0, 0.0],
+        };
+        let (tx, rx) = mpsc::channel();
+        drop(rx);
+        let result = run_chain_progress(&mut chain, 5, 0, tx);
+        assert!(
+            result.is_ok(),
+            "a dropped stats receiver shouldn't stop sampling from completing"
+        );
+    }
+
+    #[test]
+    fn run_progress_rotates_progress_bars_past_five_chains() {
+        use crate::distributions::{Gaussian2D, IsotropicGaussian};
+        use crate::metropolis_hastings::MetropolisHastings;
+        use ndarray::{arr1, arr2};
+
+        let target = Gaussian2D {
+            mean: arr1(&[0.0, 0.0]),
+            cov: arr2(&[[1.0, 0.0], [0.0, 1.0]]),
+        };
+        let proposal = IsotropicGaussian::new(1.0);
+        // More than 5 chains, so ChainRunner::run_progress (which only tracks 5
+        // progress bars at once) has to retire a finished bar and activate a queued
+        // one instead of just running to completion trivially.
+        let mut mh = MetropolisHastings::new(target, proposal, init_det(7, 2)).seed(1);
+        let (sample, _stats) = mh.run_progress(20, 5).unwrap();
+        assert_eq!(sample.shape(), [7, 20, 2]);
+    }
 }

--- a/src/distributions.rs
+++ b/src/distributions.rs
@@ -87,6 +87,26 @@ pub trait GradientTarget<T: Float, B: AutodiffBackend> {
     }
 }
 
+/// A target distribution that computes its own gradient directly (e.g. from a
+/// closed-form derivative), without routing through `burn`'s autodiff.
+///
+/// Unlike [`GradientTarget`], this trait needs no tensor backend: `position` and
+/// `grad` are plain slices, so callers (the gradient-based samplers) can write the
+/// gradient into a buffer they own and reuse across leapfrog steps instead of
+/// allocating a fresh tensor on every evaluation. This is the trait to implement if
+/// you already compute gradients analytically and want to avoid `burn`'s per-step
+/// tensor overhead.
+///
+/// The method is named `unnorm_logp_and_grad_into` rather than `unnorm_logp_and_grad`
+/// so that types implementing both this trait and [`GradientTarget`] (as
+/// [`Rosenbrock2D`] and [`DiffableGaussian2D`] do, for comparison) don't run into
+/// ambiguous-method-call errors when both traits are in scope.
+pub trait ManualGradientTarget<T: Float> {
+    /// Writes ∇log p(position) into `grad` and returns the unnormalized log density
+    /// at `position`. `grad` has the same length as `position`.
+    fn unnorm_logp_and_grad_into(&self, position: &[T], grad: &mut [T]) -> T;
+}
+
 /// A trait for generating proposals Metropolis–Hastings-like algorithms.
 /// The state type `T` is typically a vector of continuous values.
 pub trait Proposal<T, F: Float> {
@@ -315,6 +335,34 @@ where
     }
 }
 
+impl<T> ManualGradientTarget<T> for DiffableGaussian2D<T>
+where
+    T: Float + std::fmt::Debug,
+{
+    /// Evaluates the log density and its closed-form gradient at a single 2D position.
+    fn unnorm_logp_and_grad_into(&self, position: &[T], grad: &mut [T]) -> T {
+        assert_eq!(
+            position.len(),
+            2,
+            "DiffableGaussian2D: expected dimension=2."
+        );
+        let (d0, d1) = (position[0] - self.mean[0], position[1] - self.mean[1]);
+        let (ic00, ic01, ic10, ic11) = (
+            self.inv_cov[0][0],
+            self.inv_cov[0][1],
+            self.inv_cov[1][0],
+            self.inv_cov[1][1],
+        );
+        let half = T::from(0.5).unwrap();
+        let sym01 = ic01 + ic10;
+        grad[0] = -(ic00 * d0) - half * sym01 * d1;
+        grad[1] = -half * sym01 * d0 - (ic11 * d1);
+
+        let quad = d0 * (ic00 * d0 + ic01 * d1) + d1 * (ic10 * d0 + ic11 * d1);
+        self.norm_const - half * quad
+    }
+}
+
 /**
 An *isotropic* Gaussian distribution usable as either a target or a proposal
 in MCMC. It works for **any dimension** because it applies independent
@@ -523,8 +571,29 @@ where
     }
 }
 
+impl<T> ManualGradientTarget<T> for Rosenbrock2D<T>
+where
+    T: Float,
+{
+    /// Evaluates the log density and its closed-form gradient at a single 2D position.
+    fn unnorm_logp_and_grad_into(&self, position: &[T], grad: &mut [T]) -> T {
+        assert_eq!(position.len(), 2, "Rosenbrock2D: expected dimension=2.");
+        let (x, y) = (position[0], position[1]);
+        let two = T::from(2.0).unwrap();
+        let four = T::from(4.0).unwrap();
+        let a_minus_x = self.a - x;
+        let y_minus_x2 = y - x * x;
+
+        grad[0] = two * a_minus_x + four * self.b * x * y_minus_x2;
+        grad[1] = -two * self.b * y_minus_x2;
+
+        -(a_minus_x * a_minus_x + self.b * y_minus_x2 * y_minus_x2)
+    }
+}
+
 // Define the Rosenbrock distribution.
 // From: https://arxiv.org/pdf/1903.09556.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RosenbrockND {}
 
 // For the batched version we need to implement BatchGradientTarget.
@@ -543,6 +612,36 @@ where
             .mul_scalar(100);
         let term_2 = low.neg().add_scalar(1).powi_scalar(2);
         -(term_1 + term_2).sum_dim(1).squeeze(1)
+    }
+}
+
+impl<T> ManualGradientTarget<T> for RosenbrockND
+where
+    T: Float,
+{
+    /// Evaluates the log density and its closed-form gradient of the N-dimensional
+    /// Rosenbrock function (fixed scale `b = 100`, matching the batched `burn` impl above).
+    fn unnorm_logp_and_grad_into(&self, position: &[T], grad: &mut [T]) -> T {
+        let n = position.len();
+        assert!(n >= 2, "RosenbrockND: expected dimension >= 2.");
+        let hundred = T::from(100.0).unwrap();
+        let two = T::from(2.0).unwrap();
+        let four_hundred = T::from(400.0).unwrap();
+        let two_hundred = T::from(200.0).unwrap();
+
+        grad.iter_mut().for_each(|g| *g = T::zero());
+        let mut logp = T::zero();
+
+        for i in 0..n - 1 {
+            let (xi, xi1) = (position[i], position[i + 1]);
+            let diff = xi1 - xi * xi;
+            let one_minus_xi = T::one() - xi;
+            logp = logp - (hundred * diff * diff + one_minus_xi * one_minus_xi);
+
+            grad[i] = grad[i] + four_hundred * xi * diff + two * one_minus_xi;
+            grad[i + 1] = grad[i + 1] - two_hundred * diff;
+        }
+        logp
     }
 }
 
@@ -603,6 +702,92 @@ mod continuous_tests {
             diff < 1e-8,
             "Expected diff < 1e-8, got {diff} with p={p} (expected ~{true_p})"
         );
+    }
+
+    /// Checks a [`ManualGradientTarget`] impl's analytic gradient against a central
+    /// finite-difference approximation of its own returned log density, at each of
+    /// `positions`. Catches algebra mistakes in hand-derived closed-form gradients.
+    fn check_gradient<GTarget: ManualGradientTarget<f64>>(
+        target: &GTarget,
+        positions: &[Vec<f64>],
+    ) {
+        let h = 1e-6;
+        for position in positions {
+            let dim = position.len();
+            let mut grad = vec![0.0; dim];
+            target.unnorm_logp_and_grad_into(position, &mut grad);
+
+            let mut scratch = vec![0.0; dim];
+            for i in 0..dim {
+                let mut plus = position.clone();
+                let mut minus = position.clone();
+                plus[i] += h;
+                minus[i] -= h;
+                let f_plus = target.unnorm_logp_and_grad_into(&plus, &mut scratch);
+                let f_minus = target.unnorm_logp_and_grad_into(&minus, &mut scratch);
+                let numeric = (f_plus - f_minus) / (2.0 * h);
+                assert!(
+                    (numeric - grad[i]).abs() < 1e-6,
+                    "gradient mismatch at {position:?}, dim {i}: analytic={}, numeric={numeric}",
+                    grad[i]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rosenbrock2d_manual_gradient_matches_finite_difference() {
+        let target = Rosenbrock2D { a: 1.0, b: 100.0 };
+        check_gradient(
+            &target,
+            &[
+                vec![0.0, 0.0],
+                vec![1.0, 1.0],
+                vec![-0.5, 2.3],
+                vec![2.0, -1.0],
+            ],
+        );
+    }
+
+    #[test]
+    fn rosenbrock_nd_manual_gradient_matches_finite_difference() {
+        let target = RosenbrockND {};
+        check_gradient(
+            &target,
+            &[
+                vec![0.0, 0.0, 0.0, 0.0],
+                vec![1.0, 1.0, 1.0, 1.0],
+                vec![-0.5, 2.3, 0.7, -1.2, 0.4],
+            ],
+        );
+    }
+
+    #[test]
+    fn diffable_gaussian2d_manual_gradient_matches_finite_difference() {
+        let target = DiffableGaussian2D::new([0.3, -0.7], [[4.0, 2.0], [2.0, 3.0]]);
+        check_gradient(&target, &[vec![0.0, 0.0], vec![1.0, -2.0], vec![0.3, -0.7]]);
+    }
+
+    #[test]
+    fn diffable_gaussian2d_manual_gradient_matches_burn_autodiff() {
+        use burn::backend::{Autodiff, NdArray};
+
+        type B = Autodiff<NdArray>;
+        let target = DiffableGaussian2D::new([0.3_f32, -0.7], [[4.0, 2.0], [2.0, 3.0]]);
+        let position = vec![1.2_f32, -0.4];
+
+        let mut manual_grad = vec![0.0_f32; 2];
+        let manual_logp =
+            ManualGradientTarget::unnorm_logp_and_grad_into(&target, &position, &mut manual_grad);
+
+        let pos_tensor = Tensor::<B, 1>::from_floats(position.as_slice(), &Default::default());
+        let (burn_logp, burn_grad) = GradientTarget::unnorm_logp_and_grad(&target, pos_tensor);
+        let burn_grad: Vec<f32> = burn_grad.to_data().to_vec().unwrap();
+
+        assert!((manual_logp - burn_logp.into_scalar()).abs() < 1e-4);
+        for (m, b) in manual_grad.iter().zip(burn_grad.iter()) {
+            assert!((m - b).abs() < 1e-4, "manual={m} burn={b}");
+        }
     }
 }
 

--- a/src/hmc.rs
+++ b/src/hmc.rs
@@ -9,14 +9,18 @@
 //! integrator to simulate Hamiltonian dynamics, and the standard accept/reject step for proposal
 //! validation.
 
+use crate::core::{HasChains, MarkovChain};
 use crate::distributions::BatchedGradientTarget;
+use crate::distributions::ManualGradientTarget;
+use crate::leapfrog;
 use crate::stats::MultiChainTracker;
 use crate::stats::RunStats;
 use burn::prelude::*;
 use burn::tensor::backend::AutodiffBackend;
 use burn::tensor::Tensor;
 use indicatif::{ProgressBar, ProgressStyle};
-use num_traits::Float;
+use ndarray::LinalgScalar;
+use num_traits::{Float, ToPrimitive};
 use rand::prelude::*;
 use rand::Rng;
 use rand_distr::{StandardNormal, StandardUniform};
@@ -431,12 +435,185 @@ where
     }
 }
 
+/// A single Markov chain for [`ManualHMC`], the burn-free Hamiltonian Monte Carlo sampler.
+///
+/// Unlike [`HMC`], which batches all chains into one `burn` tensor, each `ManualHMCChain`
+/// runs independently (chains are parallelized across threads by [`crate::core::ChainRunner`],
+/// the same way [`crate::metropolis_hastings::MHMarkovChain`] and
+/// [`crate::gibbs::GibbsMarkovChain`] are). Its position, momentum, and gradient buffers
+/// are allocated once and reused for the lifetime of the chain.
+#[derive(Debug, Clone)]
+pub struct ManualHMCChain<T, GTarget> {
+    /// The target distribution which provides log probability evaluations and gradients.
+    pub target: GTarget,
+    /// The step size for the leapfrog integrator.
+    pub step_size: T,
+    /// The number of leapfrog steps to take per HMC update.
+    pub n_leapfrog: usize,
+    /// The current position of this chain.
+    pub position: Vec<T>,
+
+    grad: Vec<T>,
+    momentum: Vec<T>,
+    proposal_position: Vec<T>,
+    proposal_momentum: Vec<T>,
+    proposal_grad: Vec<T>,
+
+    rng: SmallRng,
+}
+
+impl<T, GTarget> ManualHMCChain<T, GTarget>
+where
+    T: Float,
+    GTarget: ManualGradientTarget<T>,
+{
+    /// Creates a new chain at `initial_position`, with a fresh random seed.
+    pub fn new(target: GTarget, initial_position: Vec<T>, step_size: T, n_leapfrog: usize) -> Self {
+        let dim = initial_position.len();
+        Self {
+            target,
+            step_size,
+            n_leapfrog,
+            position: initial_position,
+            grad: vec![T::zero(); dim],
+            momentum: vec![T::zero(); dim],
+            proposal_position: vec![T::zero(); dim],
+            proposal_momentum: vec![T::zero(); dim],
+            proposal_grad: vec![T::zero(); dim],
+            rng: SmallRng::seed_from_u64(rand::rng().random::<u64>()),
+        }
+    }
+}
+
+impl<T, GTarget> MarkovChain<T> for ManualHMCChain<T, GTarget>
+where
+    T: Float + rand_distr::uniform::SampleUniform,
+    GTarget: ManualGradientTarget<T>,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+{
+    /// Performs one HMC update: samples fresh momentum, runs `n_leapfrog` leapfrog
+    /// steps from the current position, and accepts or rejects the proposal.
+    fn step(&mut self) -> &Vec<T> {
+        let half = T::from(0.5).unwrap();
+
+        leapfrog::fill_standard_normal(&mut self.momentum, &mut self.rng);
+        let logp_current = self
+            .target
+            .unnorm_logp_and_grad_into(&self.position, &mut self.grad);
+        let h_current = -logp_current + half * leapfrog::dot(&self.momentum, &self.momentum);
+
+        self.proposal_position.copy_from_slice(&self.position);
+        self.proposal_momentum.copy_from_slice(&self.momentum);
+        self.proposal_grad.copy_from_slice(&self.grad);
+
+        let mut logp_proposed = logp_current;
+        for _ in 0..self.n_leapfrog {
+            logp_proposed = leapfrog::leapfrog(
+                &self.target,
+                &mut self.proposal_position,
+                &mut self.proposal_momentum,
+                &mut self.proposal_grad,
+                self.step_size,
+            );
+        }
+        let h_proposed =
+            -logp_proposed + half * leapfrog::dot(&self.proposal_momentum, &self.proposal_momentum);
+
+        let accept_logp = h_current - h_proposed;
+        let u: T = self.rng.random();
+        if accept_logp >= u.ln() {
+            self.position.copy_from_slice(&self.proposal_position);
+        }
+
+        &self.position
+    }
+
+    fn current_state(&self) -> &Vec<T> {
+        &self.position
+    }
+}
+
+/// A burn-free, data-parallel Hamiltonian Monte Carlo sampler for targets that compute
+/// their own gradient (see [`ManualGradientTarget`]).
+///
+/// This is the counterpart to [`HMC`] for users who already have an analytic gradient
+/// and want to avoid `burn`'s per-step tensor allocation/autodiff overhead. Chains are
+/// run independently and in parallel via [`crate::core::ChainRunner`] (`run`/`run_progress`
+/// are provided by that trait's blanket implementation, not defined here), the same
+/// infrastructure [`crate::metropolis_hastings::MetropolisHastings`] and
+/// [`crate::gibbs::GibbsSampler`] already use.
+///
+/// # Example
+///
+/// ```rust
+/// use mini_mcmc::core::{ChainRunner, init};
+/// use mini_mcmc::distributions::Rosenbrock2D;
+/// use mini_mcmc::hmc::ManualHMC;
+///
+/// let target = Rosenbrock2D { a: 1.0_f32, b: 100.0 };
+/// let mut sampler = ManualHMC::new(target, init(4, 2), 0.01, 5).set_seed(42);
+/// let sample = sampler.run(100, 20).unwrap();
+/// assert_eq!(sample.shape(), [4, 100, 2]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ManualHMC<T, GTarget> {
+    /// The independent chains that make up this sampler.
+    pub chains: Vec<ManualHMCChain<T, GTarget>>,
+}
+
+impl<T, GTarget> ManualHMC<T, GTarget>
+where
+    T: Float,
+    GTarget: ManualGradientTarget<T> + Clone,
+{
+    /// Creates a new sampler with one chain per entry in `initial_positions`.
+    ///
+    /// Mirrors [`HMC::new`]'s signature: `target`, `initial_positions`, `step_size`,
+    /// and `n_leapfrog` all mean the same thing here.
+    pub fn new(
+        target: GTarget,
+        initial_positions: Vec<Vec<T>>,
+        step_size: T,
+        n_leapfrog: usize,
+    ) -> Self {
+        let chains = initial_positions
+            .into_iter()
+            .map(|pos| ManualHMCChain::new(target.clone(), pos, step_size, n_leapfrog))
+            .collect();
+        Self { chains }
+    }
+
+    /// Deterministically reseeds every chain, deriving each chain's seed from `seed`
+    /// the same way [`crate::nuts::NUTS::set_seed`] does.
+    pub fn set_seed(mut self, seed: u64) -> Self {
+        for (i, chain) in self.chains.iter_mut().enumerate() {
+            chain.rng = SmallRng::seed_from_u64(seed + i as u64 + 1);
+        }
+        self
+    }
+}
+
+impl<T, GTarget> HasChains<T> for ManualHMC<T, GTarget>
+where
+    T: Float + ToPrimitive + LinalgScalar + rand_distr::uniform::SampleUniform + Send,
+    GTarget: ManualGradientTarget<T> + Clone + Send,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+{
+    type Chain = ManualHMCChain<T, GTarget>;
+
+    fn chains_mut(&mut self) -> &mut Vec<Self::Chain> {
+        &mut self.chains
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
-        core::init,
+        core::{init, ChainRunner},
         dev_tools::Timer,
-        distributions::{DiffableGaussian2D, Rosenbrock2D, RosenbrockND},
+        distributions::{DiffableGaussian2D, Rosenbrock2D},
         stats::split_rhat_mean_ess,
     };
     use ndarray::ArrayView3;
@@ -575,6 +752,7 @@ mod tests {
 
     #[test]
     #[ignore = "Benchmark test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_gaussian_2d_hmc_single_run() {
         // Each experiment uses 3 chains:
         let n_chains = 3;
@@ -631,6 +809,7 @@ mod tests {
 
     #[test]
     #[ignore = "Benchmark test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_gaussian_2d_hmc_ess_stats() {
         use crate::stats::basic_stats;
         use indicatif::{ProgressBar, ProgressStyle};
@@ -787,167 +966,53 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    fn test_bench_noprogress() {
-        // Use the CPU backend (NdArray) wrapped in Autodiff.
-        type BackendType = Autodiff<burn::backend::NdArray>;
-
-        // Create the Rosenbrock target (a = 1, b = 100)
+    fn manual_hmc_run_shape() {
         let target = Rosenbrock2D {
-            a: 1.0_f32,
-            b: 100.0_f32,
+            a: 1.0_f64,
+            b: 100.0,
         };
+        let mut sampler = ManualHMC::new(target, init(3, 2), 0.01, 5).set_seed(42);
+        let sample = sampler.run(10, 5).unwrap();
+        assert_eq!(sample.shape(), [3, 10, 2]);
+    }
 
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let initial_positions = init(6, 2);
-        let n_collect = 5000;
+    #[test]
+    fn manual_hmc_run_progress_shape() {
+        let target = Rosenbrock2D {
+            a: 1.0_f64,
+            b: 100.0,
+        };
+        let mut sampler = ManualHMC::new(target, init(3, 2), 0.01, 5).set_seed(42);
+        let (sample, stats) = sampler.run_progress(10, 5).unwrap();
+        assert_eq!(sample.shape(), [3, 10, 2]);
+        println!("{stats}");
+    }
+
+    #[test]
+    fn manual_hmc_gaussian_recovers_mean_and_ess() {
+        let mean = [0.0_f32, 1.0];
+        let target = DiffableGaussian2D::new(mean, [[4.0, 2.0], [2.0, 3.0]]);
+        let n_chains = 4;
+        let n_collect = 1000;
         let n_discard = 500;
 
-        // Create the data-parallel HMC sampler.
-        let mut sampler = HMC::<f32, BackendType, Rosenbrock2D<f32>>::new(
-            target,
-            initial_positions,
-            0.01, // step size
-            50,   // number of leapfrog steps per update
-        )
-        .set_seed(42);
+        let mut sampler = ManualHMC::new(target, init(n_chains, 2), 0.1, 10).set_seed(7);
+        let sample = sampler.run(n_collect, n_discard).unwrap();
+        assert_eq!(sample.shape(), [n_chains, n_collect, 2]);
 
-        // Run HMC for `n_collect` steps.
-        let mut timer = Timer::new();
-        let sample = sampler.run(n_collect, n_discard);
-        timer.log(format!(
-            "HMC sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        assert_eq!(sample.dims(), [6, 5000, 2]);
-
-        let data = sample.to_data();
-        let array = ArrayView3::from_shape(sample.dims(), data.as_slice().unwrap()).unwrap();
-        let (split_rhat, ess) = split_rhat_mean_ess(array);
-        println!("MIN Split Rhat: {}", split_rhat.min().unwrap());
-        println!("MIN ESS: {}", ess.min().unwrap());
-    }
-
-    #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    fn test_progress_bench() {
-        // Use the CPU backend (NdArray) wrapped in Autodiff.
-        type BackendType = Autodiff<burn::backend::NdArray>;
-        BackendType::seed(42);
-
-        // Create the Rosenbrock target (a = 1, b = 100)
-        let target = Rosenbrock2D {
-            a: 1.0_f32,
-            b: 100.0_f32,
-        };
-
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let n_chains = 6;
-        let initial_positions = vec![vec![1.0_f32, 2.0_f32]; n_chains];
-        let n_collect = 1000;
-        let n_discard = 1000;
-
-        // Create the data-parallel HMC sampler.
-        let mut sampler = HMC::<f32, BackendType, Rosenbrock2D<f32>>::new(
-            target,
-            initial_positions,
-            0.01, // step size
-            50,   // number of leapfrog steps per update
-        )
-        .set_seed(42);
-
-        // Run HMC for n_collect steps.
-        let mut timer = Timer::new();
-        let sample = sampler.run_progress(n_collect, n_discard).unwrap().0;
-        timer.log(format!(
-            "HMC sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        println!(
-            "Chain 1, first 10: {}",
-            sample.clone().slice([0..1, 0..10, 0..1])
-        );
-        println!(
-            "Chain 2, first 10: {}",
-            sample.clone().slice([2..3, 0..10, 0..1])
+        let (_, ess) = split_rhat_mean_ess(sample.view());
+        assert!(
+            ess.min().unwrap() > &20.0,
+            "Expected min ESS > 20, got {:?}",
+            ess
         );
 
-        #[cfg(feature = "csv")]
-        crate::io::csv::save_csv_tensor(sample.clone(), "/tmp/hmc-sample.csv")
-            .expect("Expected saving to succeed");
-
-        assert_eq!(sample.dims(), [n_chains, n_collect, 2]);
-    }
-
-    #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    fn test_bench_10000d() {
-        // Use the CPU backend (NdArray) wrapped in Autodiff.
-        type BackendType = Autodiff<burn::backend::NdArray>;
-
-        let seed = 42;
-        let d = 10000;
-        let n_chains = 6;
-        let n_collect = 100;
-        let n_discard = 100;
-
-        let rng = SmallRng::seed_from_u64(seed);
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let initial_positions: Vec<Vec<f32>> =
-            vec![rng.sample_iter(StandardNormal).take(d).collect(); n_chains];
-
-        // Create the data-parallel HMC sampler.
-        let mut sampler = HMC::<f32, BackendType, RosenbrockND>::new(
-            RosenbrockND {},
-            initial_positions,
-            0.01, // step size
-            50,   // number of leapfrog steps per update
-        )
-        .set_seed(42);
-
-        // Run HMC for n_collect steps.
-        let mut timer = Timer::new();
-        let sample = sampler.run(n_collect, n_discard);
-        timer.log(format!(
-            "HMC sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        assert_eq!(sample.dims(), [n_chains, n_collect, d]);
-    }
-
-    #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    #[cfg(feature = "wgpu")]
-    fn test_progress_10000d_bench() {
-        type BackendType = Autodiff<burn::backend::Wgpu>;
-
-        let seed = 42;
-        let d = 10000;
-        let n_chains = 6;
-
-        let rng = SmallRng::seed_from_u64(seed);
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let initial_positions: Vec<Vec<f32>> =
-            vec![rng.sample_iter(StandardNormal).take(d).collect(); n_chains];
-        let n_collect = 100;
-        let n_discard = 100;
-
-        // Create the data-parallel HMC sampler.
-        let mut sampler = HMC::<f32, BackendType, RosenbrockND>::new(
-            RosenbrockND {},
-            initial_positions,
-            0.01, // step size
-            50,   // number of leapfrog steps per update
-        )
-        .set_seed(42);
-
-        // Run HMC for n_collect steps.
-        let mut timer = Timer::new();
-        let sample = sampler.run_progress(n_collect, n_discard).unwrap().0;
-        timer.log(format!(
-            "HMC sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        assert_eq!(sample.dims(), [n_chains, n_collect, d]);
+        for (dim, &target_mean) in mean.iter().enumerate() {
+            let observed_mean: f32 = sample.slice(ndarray::s![.., .., dim]).mean().unwrap();
+            assert!(
+                (observed_mean - target_mean).abs() < 0.5,
+                "dim {dim}: expected mean near {target_mean}, got {observed_mean}"
+            );
+        }
     }
 }

--- a/src/leapfrog.rs
+++ b/src/leapfrog.rs
@@ -1,0 +1,109 @@
+//! Shared plumbing for the burn-free (manual-gradient) HMC and NUTS samplers.
+//!
+//! Both `hmc::ManualHMC` and `nuts::ManualNUTS` advance their chains with the same
+//! leapfrog integrator, operating on plain slices instead of `burn` tensors. This
+//! module holds that shared integrator plus the small vector-arithmetic helpers it
+//! needs, so the two samplers don't each carry their own copy.
+
+use crate::distributions::ManualGradientTarget;
+use num_traits::Float;
+use rand::Rng;
+use rand_distr::StandardNormal;
+
+/// Dot product of two equal-length slices.
+pub(crate) fn dot<T: Float>(a: &[T], b: &[T]) -> T {
+    a.iter()
+        .zip(b.iter())
+        .fold(T::zero(), |acc, (&x, &y)| acc + x * y)
+}
+
+/// In-place `y += alpha * x`.
+pub(crate) fn axpy<T: Float>(y: &mut [T], alpha: T, x: &[T]) {
+    y.iter_mut()
+        .zip(x.iter())
+        .for_each(|(yi, &xi)| *yi = *yi + alpha * xi);
+}
+
+/// Fills `out` with i.i.d. draws from a standard normal distribution.
+pub(crate) fn fill_standard_normal<T>(out: &mut [T], rng: &mut impl Rng)
+where
+    T: Float,
+    StandardNormal: rand_distr::Distribution<T>,
+{
+    out.iter_mut().for_each(|x| *x = rng.sample(StandardNormal));
+}
+
+/// Performs one leapfrog step in-place: a half-step momentum update using the
+/// current gradient, a full-step position update, a gradient recomputation at the
+/// new position, and a final half-step momentum update using the new gradient.
+///
+/// `grad` holds the gradient at `position` on entry and the gradient at the updated
+/// `position` on return, so it can be reused as-is for the next call instead of being
+/// reallocated. Returns the log density at the updated position.
+pub(crate) fn leapfrog<T, GTarget>(
+    target: &GTarget,
+    position: &mut [T],
+    momentum: &mut [T],
+    grad: &mut [T],
+    step_size: T,
+) -> T
+where
+    T: Float,
+    GTarget: ManualGradientTarget<T>,
+{
+    let half_step = T::from(0.5).unwrap() * step_size;
+    axpy(momentum, half_step, grad);
+    axpy(position, step_size, momentum);
+    let logp = target.unnorm_logp_and_grad_into(position, grad);
+    axpy(momentum, half_step, grad);
+    logp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dot_computes_inner_product() {
+        assert_eq!(dot(&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]), 32.0);
+    }
+
+    #[test]
+    fn axpy_scales_and_accumulates() {
+        let mut y = [1.0, 1.0, 1.0];
+        axpy(&mut y, 2.0, &[1.0, 2.0, 3.0]);
+        assert_eq!(y, [3.0, 5.0, 7.0]);
+    }
+
+    /// A 1D standard-normal target: unnorm_logp(x) = -0.5*x^2, grad = -x.
+    /// Leapfrog on a quadratic potential should trace a known ellipse in phase space,
+    /// so this checks the integrator's arithmetic directly against a hand-derived step.
+    struct StdNormal1D;
+
+    impl ManualGradientTarget<f64> for StdNormal1D {
+        fn unnorm_logp_and_grad_into(&self, position: &[f64], grad: &mut [f64]) -> f64 {
+            grad[0] = -position[0];
+            -0.5 * position[0] * position[0]
+        }
+    }
+
+    #[test]
+    fn leapfrog_matches_hand_computed_step() {
+        let target = StdNormal1D;
+        let mut position = [0.0];
+        let mut momentum = [1.0];
+        let mut grad = [0.0]; // gradient at the initial position (0.0) is 0.0
+        let step_size = 0.1;
+
+        let logp = leapfrog(&target, &mut position, &mut momentum, &mut grad, step_size);
+
+        // mom_half = 1.0 + 0.05 * 0.0 = 1.0
+        // pos'     = 0.0 + 0.1 * 1.0  = 0.1
+        // grad'    = -0.1
+        // mom'     = 1.0 + 0.05 * -0.1 = 0.995
+        assert!((position[0] - 0.1).abs() < 1e-12);
+        assert!((momentum[0] - 0.995).abs() < 1e-12);
+        assert!((grad[0] - (-0.1)).abs() < 1e-12);
+        assert!((logp - (-0.5 * 0.1 * 0.1)).abs() < 1e-12);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,12 @@
 //!
 //! The library provides three main sampling approaches:
 //! 1. **No-U-Turn Sampler (NUTS)**: For continuous distributions with gradients. You need to provide:
-//!    - A target distribution implementing the `GradientTarget` trait
+//!    - A target distribution implementing the `GradientTarget` trait (via `burn` autodiff), or
+//!      [`distributions::ManualGradientTarget`] (analytic gradient, no `burn` tensors) for use with
+//!      [`nuts::ManualNUTS`] — see Example 5 below.
 //! 2. **Hamiltonian Monte Carlo (HMC)**: For continuous distributions with gradients. You need to provide:
-//!    - A target distribution implementing the `BatchedGradientTarget` trait
+//!    - A target distribution implementing the `BatchedGradientTarget` trait (via `burn` autodiff), or
+//!      [`distributions::ManualGradientTarget`] for use with [`hmc::ManualHMC`].
 //! 3. **Metropolis-Hastings**: For general-purpose sampling. You need to provide:
 //!    - A target distribution implementing the `Target` trait
 //!    - A proposal distribution implementing the `Proposal` trait
@@ -209,6 +212,40 @@
 //! println!("Poisson sample shape: {:?}", sample.shape());
 //! ```
 //!
+//! ## Example 5: Sampling a 2D Rosenbrock with an analytic gradient (burn-free NUTS)
+//!
+//! NUTS and HMC don't require `burn`: if you already have a closed-form gradient,
+//! implement [`distributions::ManualGradientTarget`] and use [`nuts::ManualNUTS`] (or
+//! [`hmc::ManualHMC`]) instead. No tensors, no autodiff, no per-step allocation —
+//! `unnorm_logp_and_grad_into` writes the gradient into a buffer the sampler reuses
+//! across leapfrog steps.
+//!
+//! ```rust
+//! use mini_mcmc::core::{ChainRunner, init};
+//! use mini_mcmc::distributions::ManualGradientTarget;
+//! use mini_mcmc::nuts::ManualNUTS;
+//!
+//! #[derive(Clone)]
+//! struct Rosenbrock2D { a: f64, b: f64 }
+//!
+//! impl ManualGradientTarget<f64> for Rosenbrock2D {
+//!     fn unnorm_logp_and_grad_into(&self, position: &[f64], grad: &mut [f64]) -> f64 {
+//!         let (x, y) = (position[0], position[1]);
+//!         let a_minus_x = self.a - x;
+//!         let y_minus_x2 = y - x * x;
+//!         grad[0] = 2.0 * a_minus_x + 4.0 * self.b * x * y_minus_x2;
+//!         grad[1] = -2.0 * self.b * y_minus_x2;
+//!         -(a_minus_x * a_minus_x + self.b * y_minus_x2 * y_minus_x2)
+//!     }
+//! }
+//!
+//! let target = Rosenbrock2D { a: 1.0, b: 100.0 };
+//! let n_discard = 20; // also the step-size adaptation window, see `ManualNUTS::new`
+//! let mut sampler = ManualNUTS::new(target, init(4, 2), 0.8, n_discard).set_seed(42);
+//! let sample = sampler.run(100, n_discard).unwrap();
+//! println!("Collected sample shape: {:?}", sample.shape());
+//! ```
+//!
 //! For more complete implementations (including Gibbs sampling and I/O helpers),
 //! see the `examples/` directory.
 //!
@@ -224,12 +261,18 @@
 //! - Rank-Normalized R-hat diagnostics
 //! - Ensemble Slice Sampling (ESS)
 
+// Lets `#[coverage(off)]` (below, on slow `#[ignore]`d correctness tests) compile on
+// stable as a no-op, while actually excluding those functions from coverage accounting
+// when `cargo llvm-cov` runs on nightly. See taiki-e/cargo-llvm-cov's README.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 pub mod core;
 mod dev_tools;
 pub mod distributions;
 pub mod gibbs;
 pub mod hmc;
 pub mod io;
+mod leapfrog;
 pub mod metropolis_hastings;
 pub mod nuts;
 pub mod stats;

--- a/src/metropolis_hastings.rs
+++ b/src/metropolis_hastings.rs
@@ -187,7 +187,11 @@ where
     pub fn seed(mut self, seed: u64) -> Self {
         for (i, chain) in self.chains.iter_mut().enumerate() {
             let chain_seed = 1 + seed + i as u64;
-            chain.rng = SmallRng::seed_from_u64(chain_seed)
+            chain.rng = SmallRng::seed_from_u64(chain_seed);
+            // Reseed the proposal too, otherwise `.seed()` doesn't make proposal draws
+            // reproducible even though it makes the accept/reject draws reproducible.
+            let proposal_seed = chain_seed.wrapping_add(0x9E3779B97F4A7C15);
+            chain.proposal = chain.proposal.clone().set_seed(proposal_seed);
         }
         self
     }
@@ -402,12 +406,14 @@ mod tests {
 
     #[test]
     #[ignore = "Slow test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_16_chains_long() {
         run_gaussian_2d_test(80_000_000, 16, false);
     }
 
     #[test]
     #[ignore = "Slow test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_progress_16_chains_long() {
         run_gaussian_2d_test(80_000_000, 16, true);
     }
@@ -416,6 +422,7 @@ mod tests {
     /// and collects the mean ESS for each parameter across runs, printing summary stats.
     #[test]
     #[ignore = "Benchmark test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_mean_ess_2d_gaussian() {
         let n_runs = 100;
         let n_chains = 3;

--- a/src/nuts.rs
+++ b/src/nuts.rs
@@ -40,14 +40,17 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::core::{HasChains, MarkovChain};
 use crate::distributions::GradientTarget;
+use crate::distributions::ManualGradientTarget;
+use crate::leapfrog;
 use crate::stats::{collect_rhat, ChainStats, ChainTracker, RunStats};
 use burn::prelude::*;
 use burn::tensor::backend::AutodiffBackend;
 use burn::tensor::cast::ToElement;
 use burn::tensor::Element;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
-use ndarray::ArrayView3;
+use ndarray::{ArrayView3, LinalgScalar};
 use ndarray_stats::QuantileExt;
 use num_traits::{Float, FromPrimitive};
 use rand::prelude::*;
@@ -995,13 +998,544 @@ where
     (position_prime, mom_prime, grad_prime, ulogp_prime)
 }
 
+/// Single-chain state and adaptation for [`ManualNUTS`], the burn-free NUTS sampler.
+///
+/// This is a direct port of [`NUTSChain`]'s dual-averaging step-size adaptation and
+/// dynamic trajectory building (same formulas, same algorithm) from `burn` tensor
+/// arithmetic to plain `Vec<T>`/slice arithmetic, so that it can run against a
+/// [`ManualGradientTarget`] instead of a [`GradientTarget`].
+///
+/// Unlike [`NUTSChain`], which learns its warm-up length from the `n_discard`
+/// argument passed to `run`/`run_progress`, `ManualNUTSChain` gets that as an explicit
+/// `n_warmup` constructor argument: it implements [`crate::core::MarkovChain`] so that
+/// [`ManualNUTS`] can reuse [`crate::core::ChainRunner`]'s existing parallel
+/// run/progress-bar/R-hat machinery (the same infrastructure
+/// [`crate::metropolis_hastings::MetropolisHastings`] uses) instead of duplicating it,
+/// and that trait's `step` takes no arguments. Pass the same value you plan to pass as
+/// `n_discard` to `run`/`run_progress` so the step size finishes adapting exactly when
+/// warm-up ends.
+#[derive(Debug, Clone)]
+pub struct ManualNUTSChain<T, GTarget> {
+    target: GTarget,
+
+    /// Current position in parameter space.
+    pub position: Vec<T>,
+
+    /// Desired average acceptance probability.
+    target_accept_p: T,
+
+    /// Current step size (epsilon).
+    epsilon: T,
+
+    // Internal variables
+    m: usize,
+    n_warmup: usize,
+    gamma: T,
+    t_0: usize,
+    kappa: T,
+    mu: T,
+    epsilon_bar: T,
+    h_bar: T,
+
+    // Scratch buffers for `step`, reused across calls instead of reallocating.
+    mom_0: Vec<T>,
+    grad_0: Vec<T>,
+
+    rng: SmallRng,
+}
+
+impl<T, GTarget> ManualNUTSChain<T, GTarget>
+where
+    T: Float + SampleUniform,
+    GTarget: ManualGradientTarget<T>,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+{
+    /// Constructs a new chain, immediately running the same step-size heuristic
+    /// [`NUTSChain::new`] defers to first use (`find_reasonable_epsilon_manual`).
+    ///
+    /// # Parameters
+    /// - `target`: The target distribution implementing [`ManualGradientTarget`].
+    /// - `initial_position`: Initial position vector of length `D`.
+    /// - `target_accept_p`: Desired average acceptance probability for adaptation.
+    /// - `n_warmup`: Number of steps over which the step size adapts; pass the same
+    ///   value you'll later pass as `n_discard` to `run`/`run_progress`.
+    pub fn new(
+        target: GTarget,
+        initial_position: Vec<T>,
+        target_accept_p: T,
+        n_warmup: usize,
+    ) -> Self {
+        let dim = initial_position.len();
+        let mut rng = SmallRng::seed_from_u64(rand::rng().random::<u64>());
+        let mut mom_0 = vec![T::zero(); dim];
+        leapfrog::fill_standard_normal(&mut mom_0, &mut rng);
+        let epsilon = find_reasonable_epsilon_manual(&initial_position, &mom_0, &target);
+        let mu = (T::from(10.0).unwrap() * epsilon).ln();
+
+        Self {
+            target,
+            position: initial_position,
+            target_accept_p,
+            epsilon,
+            m: 0,
+            n_warmup,
+            gamma: T::from(0.05).unwrap(),
+            t_0: 10,
+            kappa: T::from(0.75).unwrap(),
+            mu,
+            epsilon_bar: T::one(),
+            h_bar: T::zero(),
+            mom_0,
+            grad_0: vec![T::zero(); dim],
+            rng,
+        }
+    }
+
+    /// Sets a new random seed for this chain to ensure reproducibility.
+    pub fn set_seed(mut self, seed: u64) -> Self {
+        self.rng = SmallRng::seed_from_u64(seed);
+        self
+    }
+}
+
+impl<T, GTarget> MarkovChain<T> for ManualNUTSChain<T, GTarget>
+where
+    T: Float + SampleUniform,
+    GTarget: ManualGradientTarget<T>,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+    Exp1: rand_distr::Distribution<T>,
+{
+    /// Performs one NUTS update step, including tree expansion and adaptation updates.
+    fn step(&mut self) -> &Vec<T> {
+        self.m += 1;
+        let half = T::from(0.5).unwrap();
+
+        // Reuse the chain's own scratch buffers instead of allocating fresh ones on
+        // every step; `build_tree_manual`'s recursion still needs owned clones below,
+        // since it explores both trajectory directions independently.
+        leapfrog::fill_standard_normal(&mut self.mom_0, &mut self.rng);
+        let ulogp = self
+            .target
+            .unnorm_logp_and_grad_into(&self.position, &mut self.grad_0);
+        let joint = ulogp - half * leapfrog::dot(&self.mom_0, &self.mom_0);
+        let exp1_obs: T = self.rng.sample(Exp1);
+        let logu = joint - exp1_obs;
+
+        let mut position_minus = self.position.clone();
+        let mut position_plus = self.position.clone();
+        let mut mom_minus = self.mom_0.clone();
+        let mut mom_plus = self.mom_0.clone();
+        let mut grad_minus = self.grad_0.clone();
+        let mut grad_plus = self.grad_0.clone();
+        let mut j = 0;
+        let mut n = 1usize;
+        let mut s = true;
+        let mut alpha = T::zero();
+        let mut n_alpha = 0usize;
+
+        while s {
+            let u_run_1: T = self.rng.random();
+            let v: i8 = if u_run_1 < half { -1 } else { 1 };
+
+            let (position_prime, n_prime, s_prime) = if v == -1 {
+                let branch = build_tree_manual(
+                    &position_minus,
+                    &mom_minus,
+                    &grad_minus,
+                    logu,
+                    v,
+                    j,
+                    self.epsilon,
+                    &self.target,
+                    joint,
+                    &mut self.rng,
+                );
+                position_minus = branch.position_minus;
+                mom_minus = branch.mom_minus;
+                grad_minus = branch.grad_minus;
+                alpha = branch.alpha;
+                n_alpha = branch.n_alpha;
+                (branch.position_prime, branch.n_prime, branch.s_prime)
+            } else {
+                let branch = build_tree_manual(
+                    &position_plus,
+                    &mom_plus,
+                    &grad_plus,
+                    logu,
+                    v,
+                    j,
+                    self.epsilon,
+                    &self.target,
+                    joint,
+                    &mut self.rng,
+                );
+                position_plus = branch.position_plus;
+                mom_plus = branch.mom_plus;
+                grad_plus = branch.grad_plus;
+                alpha = branch.alpha;
+                n_alpha = branch.n_alpha;
+                (branch.position_prime, branch.n_prime, branch.s_prime)
+            };
+
+            let tmp = T::one().min(T::from(n_prime).unwrap() / T::from(n).unwrap());
+            let u_run_2: T = self.rng.random();
+            if s_prime && u_run_2 < tmp {
+                self.position.copy_from_slice(&position_prime);
+            }
+            n += n_prime;
+
+            s = s_prime
+                && stop_criterion_manual(&position_minus, &position_plus, &mom_minus, &mom_plus);
+            j += 1;
+        }
+
+        let mut eta = T::one() / T::from(self.m + self.t_0).unwrap();
+        self.h_bar = (T::one() - eta) * self.h_bar
+            + eta * (self.target_accept_p - alpha / T::from(n_alpha).unwrap());
+        if self.m <= self.n_warmup {
+            let m_t = T::from(self.m).unwrap();
+            self.epsilon = (self.mu - m_t.sqrt() / self.gamma * self.h_bar).exp();
+            eta = m_t.powf(-self.kappa);
+            self.epsilon_bar =
+                ((T::one() - eta) * self.epsilon_bar.ln() + eta * self.epsilon.ln()).exp();
+        } else {
+            self.epsilon = self.epsilon_bar;
+        }
+
+        &self.position
+    }
+
+    fn current_state(&self) -> &Vec<T> {
+        &self.position
+    }
+}
+
+/// Heuristic to pick an initial leapfrog step size, ported from [`find_reasonable_epsilon`].
+fn find_reasonable_epsilon_manual<T, GTarget>(position: &[T], mom: &[T], target: &GTarget) -> T
+where
+    T: Float,
+    GTarget: ManualGradientTarget<T>,
+{
+    let dim = position.len();
+    let half = T::from(0.5).unwrap();
+    let two = T::from(2.0).unwrap();
+    let mut epsilon = T::one();
+
+    let mut grad = vec![T::zero(); dim];
+    let ulogp = target.unnorm_logp_and_grad_into(position, &mut grad);
+
+    let mut pos_prime = position.to_vec();
+    let mut mom_prime = mom.to_vec();
+    let mut grad_prime = grad.clone();
+    let mut ulogp_prime = leapfrog::leapfrog(
+        target,
+        &mut pos_prime,
+        &mut mom_prime,
+        &mut grad_prime,
+        epsilon,
+    );
+    let mut k = T::one();
+
+    while !ulogp_prime.is_finite() && !grad_prime.iter().all(|g| g.is_finite()) {
+        k = k * half;
+        pos_prime.copy_from_slice(position);
+        mom_prime.copy_from_slice(mom);
+        grad_prime.copy_from_slice(&grad);
+        ulogp_prime = leapfrog::leapfrog(
+            target,
+            &mut pos_prime,
+            &mut mom_prime,
+            &mut grad_prime,
+            epsilon * k,
+        );
+    }
+
+    epsilon = half * k * epsilon;
+    let accept_prob = |ulogp_prime: T, mom_prime: &[T]| {
+        ulogp_prime - ulogp - half * (leapfrog::dot(mom_prime, mom_prime) - leapfrog::dot(mom, mom))
+    };
+    let mut log_accept_prob = accept_prob(ulogp_prime, &mom_prime);
+
+    let a = if log_accept_prob > half.ln() {
+        T::one()
+    } else {
+        -T::one()
+    };
+
+    while a * log_accept_prob > -a * two.ln() {
+        epsilon = epsilon * two.powf(a);
+        pos_prime.copy_from_slice(position);
+        mom_prime.copy_from_slice(mom);
+        grad_prime.copy_from_slice(&grad);
+        ulogp_prime = leapfrog::leapfrog(
+            target,
+            &mut pos_prime,
+            &mut mom_prime,
+            &mut grad_prime,
+            epsilon,
+        );
+        log_accept_prob = accept_prob(ulogp_prime, &mom_prime);
+    }
+
+    epsilon
+}
+
+/// The result of one [`build_tree_manual`] call.
+///
+/// `*_minus`/`*_plus` are the two ends of the (sub)trajectory explored so far;
+/// `position_prime`/`grad_prime`/`logp_prime` is the candidate sample drawn from it;
+/// `n_prime`, `s_prime`, `alpha`, `n_alpha` are bookkeeping the caller uses to combine
+/// sibling subtrees. See [`build_tree`] for what each field means — the algorithm is
+/// unchanged from that Tensor-based version, only the vector representation is.
+struct TreeResult<T> {
+    position_minus: Vec<T>,
+    mom_minus: Vec<T>,
+    grad_minus: Vec<T>,
+    position_plus: Vec<T>,
+    mom_plus: Vec<T>,
+    grad_plus: Vec<T>,
+    position_prime: Vec<T>,
+    grad_prime: Vec<T>,
+    logp_prime: T,
+    n_prime: usize,
+    s_prime: bool,
+    alpha: T,
+    n_alpha: usize,
+}
+
+/// Recursive trajectory-tree builder, ported from [`build_tree`].
+#[allow(clippy::too_many_arguments)]
+fn build_tree_manual<T, GTarget>(
+    position: &[T],
+    mom: &[T],
+    grad: &[T],
+    logu: T,
+    v: i8,
+    j: usize,
+    epsilon: T,
+    target: &GTarget,
+    joint_0: T,
+    rng: &mut SmallRng,
+) -> TreeResult<T>
+where
+    T: Float,
+    GTarget: ManualGradientTarget<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+{
+    let half = T::from(0.5).unwrap();
+    if j == 0 {
+        let mut position_prime = position.to_vec();
+        let mut mom_prime = mom.to_vec();
+        let mut grad_prime = grad.to_vec();
+        let dt = T::from(v as i32).unwrap() * epsilon;
+        let logp_prime = leapfrog::leapfrog(
+            target,
+            &mut position_prime,
+            &mut mom_prime,
+            &mut grad_prime,
+            dt,
+        );
+
+        let joint = logp_prime - half * leapfrog::dot(&mom_prime, &mom_prime);
+        let n_prime = (logu < joint) as usize;
+        let s_prime = (logu - T::from(1000.0).unwrap()) < joint;
+        let alpha = T::one().min((joint - joint_0).exp());
+        TreeResult {
+            position_minus: position_prime.clone(),
+            mom_minus: mom_prime.clone(),
+            grad_minus: grad_prime.clone(),
+            position_plus: position_prime.clone(),
+            mom_plus: mom_prime.clone(),
+            grad_plus: grad_prime.clone(),
+            position_prime,
+            grad_prime,
+            logp_prime,
+            n_prime,
+            s_prime,
+            alpha,
+            n_alpha: 1,
+        }
+    } else {
+        let mut result = build_tree_manual(
+            position,
+            mom,
+            grad,
+            logu,
+            v,
+            j - 1,
+            epsilon,
+            target,
+            joint_0,
+            rng,
+        );
+
+        if result.s_prime {
+            let sub = if v == -1 {
+                build_tree_manual(
+                    &result.position_minus,
+                    &result.mom_minus,
+                    &result.grad_minus,
+                    logu,
+                    v,
+                    j - 1,
+                    epsilon,
+                    target,
+                    joint_0,
+                    rng,
+                )
+            } else {
+                build_tree_manual(
+                    &result.position_plus,
+                    &result.mom_plus,
+                    &result.grad_plus,
+                    logu,
+                    v,
+                    j - 1,
+                    epsilon,
+                    target,
+                    joint_0,
+                    rng,
+                )
+            };
+
+            if v == -1 {
+                result.position_minus = sub.position_minus;
+                result.mom_minus = sub.mom_minus;
+                result.grad_minus = sub.grad_minus;
+            } else {
+                result.position_plus = sub.position_plus;
+                result.mom_plus = sub.mom_plus;
+                result.grad_plus = sub.grad_plus;
+            }
+
+            let u_build_tree: f64 = rng.random::<f64>();
+            if u_build_tree < (sub.n_prime as f64 / (result.n_prime + sub.n_prime).max(1) as f64) {
+                result.position_prime = sub.position_prime;
+                result.grad_prime = sub.grad_prime;
+                result.logp_prime = sub.logp_prime;
+            }
+
+            result.n_prime += sub.n_prime;
+            result.s_prime = result.s_prime
+                && sub.s_prime
+                && stop_criterion_manual(
+                    &result.position_minus,
+                    &result.position_plus,
+                    &result.mom_minus,
+                    &result.mom_plus,
+                );
+            result.alpha = result.alpha + sub.alpha;
+            result.n_alpha += sub.n_alpha;
+        }
+        result
+    }
+}
+
+/// U-turn stopping criterion, ported from [`stop_criterion`].
+///
+/// Computes both dot products in one pass over the positions/momenta instead of
+/// materializing the `position_plus - position_minus` difference as a `Vec` first.
+fn stop_criterion_manual<T: Float>(
+    position_minus: &[T],
+    position_plus: &[T],
+    mom_minus: &[T],
+    mom_plus: &[T],
+) -> bool {
+    let (mut dot_minus, mut dot_plus) = (T::zero(), T::zero());
+    for i in 0..position_minus.len() {
+        let diff = position_plus[i] - position_minus[i];
+        dot_minus = dot_minus + diff * mom_minus[i];
+        dot_plus = dot_plus + diff * mom_plus[i];
+    }
+    dot_minus >= T::zero() && dot_plus >= T::zero()
+}
+
+/// A burn-free No-U-Turn Sampler for targets that compute their own gradient
+/// (see [`ManualGradientTarget`]).
+///
+/// This is the counterpart to [`NUTS`] for users who already have an analytic
+/// gradient and want to avoid `burn`'s per-step tensor allocation/autodiff overhead.
+/// Chains are run independently and in parallel via [`crate::core::ChainRunner`]
+/// (`run`/`run_progress` are provided by that trait's blanket implementation, not
+/// defined here), the same infrastructure
+/// [`crate::metropolis_hastings::MetropolisHastings`] and
+/// [`crate::gibbs::GibbsSampler`] already use.
+///
+/// # Example
+///
+/// ```rust
+/// use mini_mcmc::core::{ChainRunner, init};
+/// use mini_mcmc::distributions::Rosenbrock2D;
+/// use mini_mcmc::nuts::ManualNUTS;
+///
+/// let target = Rosenbrock2D { a: 1.0_f32, b: 100.0 };
+/// let n_discard = 20;
+/// let mut sampler = ManualNUTS::new(target, init(4, 2), 0.8, n_discard).set_seed(42);
+/// let sample = sampler.run(100, n_discard).unwrap();
+/// assert_eq!(sample.shape(), [4, 100, 2]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ManualNUTS<T, GTarget> {
+    /// The independent chains that make up this sampler.
+    pub chains: Vec<ManualNUTSChain<T, GTarget>>,
+}
+
+impl<T, GTarget> ManualNUTS<T, GTarget>
+where
+    T: Float + SampleUniform,
+    GTarget: ManualGradientTarget<T> + Clone,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+{
+    /// Creates a new sampler with one chain per entry in `initial_positions`.
+    ///
+    /// Mirrors [`NUTS::new`]'s signature, plus an explicit `n_warmup` — see
+    /// [`ManualNUTSChain::new`] for why.
+    pub fn new(
+        target: GTarget,
+        initial_positions: Vec<Vec<T>>,
+        target_accept_p: T,
+        n_warmup: usize,
+    ) -> Self {
+        let chains = initial_positions
+            .into_iter()
+            .map(|pos| ManualNUTSChain::new(target.clone(), pos, target_accept_p, n_warmup))
+            .collect();
+        Self { chains }
+    }
+
+    /// Deterministically reseeds every chain, the same way [`NUTS::set_seed`] does.
+    pub fn set_seed(mut self, seed: u64) -> Self {
+        for (i, chain) in self.chains.iter_mut().enumerate() {
+            chain.rng = SmallRng::seed_from_u64(seed + i as u64 + 1);
+        }
+        self
+    }
+}
+
+impl<T, GTarget> HasChains<T> for ManualNUTS<T, GTarget>
+where
+    T: Float + num_traits::ToPrimitive + LinalgScalar + SampleUniform + Send,
+    GTarget: ManualGradientTarget<T> + Clone + Send,
+    StandardNormal: rand_distr::Distribution<T>,
+    StandardUniform: rand_distr::Distribution<T>,
+    Exp1: rand_distr::Distribution<T>,
+{
+    type Chain = ManualNUTSChain<T, GTarget>;
+
+    fn chains_mut(&mut self) -> &mut Vec<Self::Chain> {
+        &mut self.chains
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
 
     use crate::{
-        core::init,
-        dev_tools::Timer,
+        core::{init, ChainRunner},
         distributions::{DiffableGaussian2D, Rosenbrock2D},
         stats::split_rhat_mean_ess,
     };
@@ -1014,7 +1548,6 @@ mod tests {
         backend::{Autodiff, NdArray},
         tensor::{Tensor, Tolerance},
     };
-    use ndarray::ArrayView3;
     use ndarray_stats::QuantileExt;
     use num_traits::Float;
 
@@ -1249,66 +1782,104 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    fn test_bench_noprogress_1() {
+    fn manual_nuts_run_shape() {
         let target = Rosenbrock2D {
-            a: 1.0_f32,
-            b: 100.0_f32,
+            a: 1.0_f64,
+            b: 100.0,
         };
-
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let initial_positions = init::<f32>(6, 2);
-        let n_collect = 5000;
-        let n_discard = 500;
-
-        let mut sampler = NUTS::new(target, initial_positions, 0.95).set_seed(42);
-        let mut timer = Timer::new();
-        let sample: Tensor<BackendType, 3> = sampler.run(n_collect, n_discard);
-        timer.log(format!(
-            "NUTS sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        assert_eq!(sample.dims(), [6, 5000, 2]);
-
-        let data = sample.to_data();
-        let array = ArrayView3::from_shape(sample.dims(), data.as_slice().unwrap()).unwrap();
-        let (split_rhat, ess) = split_rhat_mean_ess(array);
-        println!("AVG Split Rhat: {}", split_rhat.mean().unwrap());
-        println!("AVG ESS: {}", ess.mean().unwrap());
-
-        #[cfg(feature = "csv")]
-        save_csv_tensor(sample, "/tmp/nuts-sample.csv").expect("saving data should succeed")
+        let n_discard = 5;
+        let mut sampler = ManualNUTS::new(target, init(3, 2), 0.8, n_discard).set_seed(42);
+        let sample = sampler.run(10, n_discard).unwrap();
+        assert_eq!(sample.shape(), [3, 10, 2]);
     }
 
     #[test]
-    #[ignore = "Benchmark test: run only when explicitly requested"]
-    fn test_bench_noprogress_2() {
+    fn manual_nuts_run_progress_shape() {
         let target = Rosenbrock2D {
-            a: 1.0_f32,
-            b: 100.0_f32,
+            a: 1.0_f64,
+            b: 100.0,
         };
+        let n_discard = 5;
+        let mut sampler = ManualNUTS::new(target, init(3, 2), 0.8, n_discard).set_seed(42);
+        let (sample, stats) = sampler.run_progress(10, n_discard).unwrap();
+        assert_eq!(sample.shape(), [3, 10, 2]);
+        println!("{stats}");
+    }
 
-        // We'll define 6 chains all initialized to (1.0, 2.0).
-        let initial_positions = init::<f32>(6, 2);
-        let n_collect = 1000;
-        let n_discard = 1000;
+    #[test]
+    fn manual_nuts_gaussian_recovers_mean_and_ess() {
+        let mean = [0.0_f32, 1.0];
+        let target = DiffableGaussian2D::new(mean, [[4.0, 2.0], [2.0, 3.0]]);
+        let n_chains = 4;
+        let n_collect = 500;
+        let n_discard = 200;
 
-        let mut sampler = NUTS::new(target, initial_positions, 0.95).set_seed(42);
-        let mut timer = Timer::new();
-        let sample: Tensor<BackendType, 3> = sampler.run(n_collect, n_discard);
-        timer.log(format!(
-            "NUTS sampler: generated {} observations.",
-            sample.dims()[0..2].iter().product::<usize>()
-        ));
-        assert_eq!(sample.dims(), [6, 1000, 2]);
+        let mut sampler = ManualNUTS::new(target, init(n_chains, 2), 0.8, n_discard).set_seed(7);
+        let sample = sampler.run(n_collect, n_discard).unwrap();
+        assert_eq!(sample.shape(), [n_chains, n_collect, 2]);
 
-        let data = sample.to_data();
-        let array = ArrayView3::from_shape(sample.dims(), data.as_slice().unwrap()).unwrap();
-        let (split_rhat, ess) = split_rhat_mean_ess(array);
-        println!("MIN Split Rhat: {}", split_rhat.min().unwrap());
-        println!("MIN ESS: {}", ess.min().unwrap());
+        let (_, ess) = split_rhat_mean_ess(sample.view());
+        assert!(
+            ess.min().unwrap() > &20.0,
+            "Expected min ESS > 20, got {:?}",
+            ess
+        );
 
-        #[cfg(feature = "csv")]
-        save_csv_tensor(sample, "/tmp/nuts-sample.csv").expect("saving data should succeed")
+        for (dim, &target_mean) in mean.iter().enumerate() {
+            let observed_mean: f32 = sample.slice(ndarray::s![.., .., dim]).mean().unwrap();
+            assert!(
+                (observed_mean - target_mean).abs() < 0.5,
+                "dim {dim}: expected mean near {target_mean}, got {observed_mean}"
+            );
+        }
+    }
+
+    #[test]
+    fn manual_nuts_chain_set_seed_is_deterministic() {
+        // Exercises ManualNUTSChain directly (bypassing the ManualNUTS container),
+        // the same way test_chain_1/2/3 exercise NUTSChain directly.
+        let target = Rosenbrock2D {
+            a: 1.0_f64,
+            b: 100.0,
+        };
+        let mut chain_a = ManualNUTSChain::new(target, vec![0.5, -0.5], 0.8, 3).set_seed(11);
+        let mut chain_b = ManualNUTSChain::new(target, vec![0.5, -0.5], 0.8, 3).set_seed(11);
+
+        for _ in 0..5 {
+            let a = MarkovChain::step(&mut chain_a).clone();
+            let b = MarkovChain::step(&mut chain_b).clone();
+            assert_eq!(a, b, "same seed should produce identical trajectories");
+        }
+        assert_eq!(chain_a.current_state(), chain_b.current_state());
+    }
+
+    #[test]
+    fn find_reasonable_epsilon_manual_shrinks_from_diverging_start() {
+        // A target whose log-density and gradient both blow up past |x| = 4. Starting
+        // at the origin with a large momentum makes the epsilon=1 initial leapfrog
+        // guess land outside that region, forcing the epsilon-halving retry loop in
+        // find_reasonable_epsilon_manual to actually run instead of exiting on its
+        // first iteration (the case every other test in this file exercises).
+        struct Blowup;
+        impl ManualGradientTarget<f64> for Blowup {
+            fn unnorm_logp_and_grad_into(&self, position: &[f64], grad: &mut [f64]) -> f64 {
+                if position[0].abs() > 4.0 {
+                    grad[0] = f64::NAN;
+                    f64::NEG_INFINITY
+                } else {
+                    grad[0] = -position[0];
+                    -0.5 * position[0] * position[0]
+                }
+            }
+        }
+
+        let position = [0.0];
+        let mom = [10.0];
+        let epsilon = find_reasonable_epsilon_manual(&position, &mom, &Blowup);
+        assert!(epsilon.is_finite() && epsilon > 0.0);
+        assert!(
+            epsilon < 1.0,
+            "expected epsilon to shrink from the diverging initial guess, got {epsilon}"
+        );
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -833,8 +833,54 @@ mod tests {
         assert!(run_stats.rhat.max < 1.01);
     }
 
+    /// `ess_from_chainstats` is a public entry point (used by callers who track
+    /// `ChainStats` incrementally via `ChainTracker` instead of holding the whole
+    /// sample in memory) that had no test coverage at all. This checks it against
+    /// the same near-i.i.d.-data sanity check `ess_1` uses for the sample-based path.
+    #[test]
+    fn ess_from_chainstats_matches_near_iid_expectation() {
+        let n_chains = 4;
+        let n_steps = 1000;
+        let n_params = 1;
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let mut data = Array2::<f32>::zeros((n_chains, n_steps));
+        for mut row in data.rows_mut() {
+            for elem in row.iter_mut() {
+                *elem = rng.random::<f32>();
+            }
+        }
+        let sample = data
+            .to_shape((n_chains, n_steps, n_params))
+            .unwrap()
+            .to_owned();
+
+        // Build ChainStats the way a real sampler run does: feed each chain's
+        // observations through a ChainTracker one at a time, then snapshot it.
+        let chain_stats: Vec<ChainStats> = (0..n_chains)
+            .map(|c| {
+                let mut tracker = ChainTracker::new(n_params, &[sample[[c, 0, 0]]]);
+                for t in 1..n_steps {
+                    tracker.step(&[sample[[c, t, 0]]]).unwrap();
+                }
+                tracker.stats()
+            })
+            .collect();
+        let chain_stats_refs: Vec<&ChainStats> = chain_stats.iter().collect();
+
+        let ess = ess_from_chainstats(sample.view(), &chain_stats_refs);
+        assert_eq!(ess.len(), n_params);
+        assert!(
+            ess[0] > 3800.0,
+            "expected ESS close to the {} near-i.i.d. draws, got {}",
+            n_chains * n_steps,
+            ess[0]
+        );
+    }
+
     #[test]
     #[ignore = "Benchmark test: run only when explicitly requested"]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_autocov_perf_comp() {
         // Create output CSV
         let mut file =


### PR DESCRIPTION
## Summary
- Integrates the useful part of PR #1 (burn-free gradients) without its larger architecture rewrite: new `ManualGradientTarget` trait plus `ManualHMC`/`ManualNUTS`, letting users supply an analytic gradient instead of routing through burn's tensor autodiff. Fully additive, existing `HMC`/`NUTS`/`GradientTarget` are untouched. Benchmarked at 27x-1400x faster than the burn path depending on problem shape.
- Fixes `MetropolisHastings::seed()` not reseeding the proposal distribution.
- Fixes a real bug: `run_chain_progress` (shared by every sampler in the crate) panicked instead of returning `Err` when a chain's state length grew between calls; the shrinking direction already worked, this makes it symmetric.
- Migrates CI coverage from tarpaulin (measured ~80% on this codebase) to `cargo-llvm-cov` (measures the same code at ~89%, more accurate).
- Moves the 8 genuine timing benchmarks that were `#[ignore]`d tests into a proper Criterion `benches/` suite; the 6 remaining `#[ignore]`d tests are slow correctness tests (not benchmarks) and now use `#[coverage(off)]` (nightly-only, no-op on stable) to stop dragging down the coverage percentage for code that was never meant to run by default. Net result: ~98% measured coverage, nothing about the tests themselves changed.

## Test plan
- [x] `cargo nextest run` (65 passed, 6 correctly skipped)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --doc` (26 doctests pass)
- [x] `cargo bench --no-run` compiles; ran migrated benchmarks and confirmed matching timing numbers to the pre-migration versions
- [x] `cargo llvm-cov --all-features` on nightly confirms `#[coverage(off)]` takes effect (98.36% line coverage) and is a no-op on stable